### PR TITLE
remove config.json from repo

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,0 @@
-{
-	"api_key": "",
-	"domain": "",
-	"dynamic_records": [
-	""
-	]
-}


### PR DESCRIPTION
config.json being in the repo is problematic for updates - `git pull` can throw an error if there are changes to it, esp when run by system automation tools (e.g. ansible). .example being present should probably be sufficient, yes?